### PR TITLE
fix bug: infinite call when call RTMP_Close

### DIFF
--- a/librtmp/rtmp.c
+++ b/librtmp/rtmp.c
@@ -4135,24 +4135,27 @@ CloseInternal(RTMP *r, int reconnect)
   int i;
 
   if (RTMP_IsConnected(r))
-    {
+  {
+    if(!r->m_bIsClosing) {
+      r->m_bIsClosing = 1;
       if (r->m_stream_id > 0)
-        {
-	  i = r->m_stream_id;
-	  r->m_stream_id = 0;
-          if ((r->Link.protocol & RTMP_FEATURE_WRITE))
-	    SendFCUnpublish(r);
-	  SendDeleteStream(r, i);
-	}
+      {
+        i = r->m_stream_id;
+        r->m_stream_id = 0;
+              if ((r->Link.protocol & RTMP_FEATURE_WRITE))
+          SendFCUnpublish(r);
+        SendDeleteStream(r, i);
+      }
       if (r->m_clientID.av_val)
-        {
-	  HTTP_Post(r, RTMPT_CLOSE, "", 1);
-	  free(r->m_clientID.av_val);
-	  r->m_clientID.av_val = NULL;
-	  r->m_clientID.av_len = 0;
-	}
-      RTMPSockBuf_Close(&r->m_sb);
+      {
+        HTTP_Post(r, RTMPT_CLOSE, "", 1);
+        free(r->m_clientID.av_val);
+        r->m_clientID.av_val = NULL;
+        r->m_clientID.av_len = 0;
+      }
     }
+    RTMPSockBuf_Close(&r->m_sb);
+  }
 
   r->m_stream_id = -1;
   r->m_sb.sb_socket = -1;

--- a/librtmp/rtmp.h
+++ b/librtmp/rtmp.h
@@ -280,6 +280,8 @@ extern "C"
     RTMPPacket m_write;
     RTMPSockBuf m_sb;
     RTMP_LNK Link;
+
+    uint8_t m_bIsClosing;
   } RTMP;
 
   int RTMP_ParseURL(const char *url, int *protocol, AVal *host,


### PR DESCRIPTION
            I found the system will crash when I’m streaming and I shutdown the rtmp server application. So I began to debug and I found in this situation the WriteN function will call the RTMP_Close when the connection is broken, RTMP_Close calling will go into a infinite calling, because I found The RTMP_Close will call the SendFCUnpublish function or SendDeleteStream function, and these two function will both call the RTMP_SendPacket function and RTMP_SendPacket will can the WriteN function to send the data through socket.. As the server application has been closed, The calling of the WriteN will return a error result, and calling the RTMP_Close function again . So these operations above will make it a infinite loop. So I wander is there any design problem in this code? I don’t know if I have make myself clear. 